### PR TITLE
Cray fixes

### DIFF
--- a/cmake/SetCompileFlag.cmake
+++ b/cmake/SetCompileFlag.cmake
@@ -43,6 +43,9 @@ FUNCTION(SET_COMPILE_FLAG FLAGVAR FLAGVAL LANG)
             "[Uu]nknown option"                   # HP
             "[Ww]arning: [Oo]ption"               # SunPro
             "command option .* is not recognized" # XL
+            "cannot find"                         # Cray when using /unroll for example
+            "ERROR in command line"               # Cray
+            "option is not supported or invalid and will be ignored" # Cray
            )
     ENDIF(LANG STREQUAL "Fortran")
 
@@ -86,7 +89,7 @@ end program dummyprog
             FOREACH(rx ${FAIL_REGEX})
                 IF("${OUTPUT}" MATCHES "${rx}")
                     SET(FLAG_WORKS FALSE)
-                ENDIF("${OUTPUT}" MATCHES "${rx}")
+                ENDIF()
             ENDFOREACH(rx ${FAIL_REGEX})
 
         ELSE()

--- a/cmake/SetFortranFlags.cmake
+++ b/cmake/SetFortranFlags.cmake
@@ -44,7 +44,7 @@ ENDIF(CMAKE_Fortran_FLAGS_RELEASE AND CMAKE_Fortran_FLAGS_TESTING AND CMAKE_Fort
 # For each option type, a list of possible flags is given that work
 # for various compilers.  The first flag that works is chosen.
 # If none of the flags work, nothing is added (unless the REQUIRED 
-# flag is given in the call).  This way unknown compiles are supported.
+# flag is given in the call).  This way unknown compilers are supported.
 #######################################################################
 
 #####################
@@ -62,12 +62,12 @@ ELSE()
     SET(GNUNATIVE "-march=native")
 ENDIF()
 # Optimize for the host's architecture
-SET_COMPILE_FLAG(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS}"
-                 Fortran "-xHost"        # Intel
-                         "/QxHost"       # Intel Windows
-                         ${GNUNATIVE}    # GNU
-                         "-ta=host"      # Portland Group
-                )
+# SET_COMPILE_FLAG(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS}"
+#                  Fortran "-xHost"        # Intel
+#                          "/QxHost"       # Intel Windows
+#                          ${GNUNATIVE}    # GNU
+#                          "-ta=host"      # Portland Group
+#                 )
 
 ###################
 ### DEBUG FLAGS ###
@@ -84,26 +84,29 @@ SET_COMPILE_FLAG(CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG}"
 # Turn on all warnings 
 SET_COMPILE_FLAG(CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG}"
                  Fortran "-warn all" # Intel
-                         "/warn:all" # Intel Windows
                          "-Wall"     # GNU
+                         "-h error_on_warning" # Cray
                                      # Portland Group (on by default)
+                         "/warn:all" # Intel Windows
                 )
 
 # Traceback
 SET_COMPILE_FLAG(CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG}"
                  Fortran "-traceback"   # Intel/Portland Group
-                         "/traceback"   # Intel Windows
                          "-fbacktrace"  # GNU (gfortran)
                          "-ftrace=full" # GNU (g95)
+                         "-G0"          # Cray
+                         "/traceback"   # Intel Windows
                 )
 
 # Check array bounds
 SET_COMPILE_FLAG(CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG}"
                  Fortran "-check bounds"  # Intel
-                         "/check:bounds"  # Intel Windows
                          "-fcheck=bounds" # GNU (New style)
                          "-fbounds-check" # GNU (Old style)
                          "-Mbounds"       # Portland Group
+                         "-h bounds"      # Cray
+                         "/check:bounds"  # Intel Windows
                 )
 
 #####################
@@ -126,31 +129,34 @@ SET_COMPILE_FLAG(CMAKE_Fortran_FLAGS_TESTING "${CMAKE_Fortran_FLAGS_TESTING}"
 SET_COMPILE_FLAG(CMAKE_Fortran_FLAGS_RELEASE "${CMAKE_Fortran_FLAGS_RELEASE}"
                  Fortran "-funroll-loops" # GNU
                          "-unroll"        # Intel
-                         "/unroll"        # Intel Windows
                          "-Munroll"       # Portland Group
+                         "-h unroll2"     # Cray
+                         "/unroll"        # Intel Windows
                 )
 
 # Inline functions
 SET_COMPILE_FLAG(CMAKE_Fortran_FLAGS_RELEASE "${CMAKE_Fortran_FLAGS_RELEASE}"
                  Fortran "-inline"            # Intel
-                         "/Qinline"           # Intel Windows
                          "-finline-functions" # GNU
                          "-Minline"           # Portland Group
+                         "-h fusion1"         # Cray max is 2
+                         "/Qinline"           # Intel Windows
                 )
 
 # Interprocedural (link-time) optimizations
 SET_COMPILE_FLAG(CMAKE_Fortran_FLAGS_RELEASE "${CMAKE_Fortran_FLAGS_RELEASE}"
                  Fortran "-ipo"     # Intel
-                         "/Qipo"    # Intel Windows
                          "-flto"    # GNU
                          "-Mipa"    # Portland Group
+                         "-h ipa2"  # Cray max is 5
+                         "/Qipo"    # Intel Windows
                 )
 
 # Single-file optimizations
-SET_COMPILE_FLAG(CMAKE_Fortran_FLAGS_RELEASE "${CMAKE_Fortran_FLAGS_RELEASE}"
-                 Fortran "-ip"  # Intel
-                         "/Qip" # Intel Windows
-                )
+# SET_COMPILE_FLAG(CMAKE_Fortran_FLAGS_RELEASE "${CMAKE_Fortran_FLAGS_RELEASE}"
+#                  Fortran "-ip"  # Intel
+#                          "/Qip" # Intel Windows
+#                 )
 
 # Vectorize code
 #SET_COMPILE_FLAG(CMAKE_Fortran_FLAGS_RELEASE "${CMAKE_Fortran_FLAGS_RELEASE}"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,10 @@ if(${Fortran_COMPILER_NAME} MATCHES "ifort.*" OR ${Fortran_COMPILER_NAME} MATCHE
         set(FLAG_L80 -80)
         set(FLAG_LLONG -132)
     endif()
+elseif(${CMAKE_Fortran_COMPILER_ID} STREQUAL "Cray") 
+    set(FLAG_L72 -N72)
+    set(FLAG_L80 -N80)
+    set(FLAG_LLONG -N132)
 else() # gfortran tested only
     set(FLAG_L72 -ffixed-line-length-72)
     set(FLAG_L80 -ffixed-line-length-80)

--- a/src/biofilm.f
+++ b/src/biofilm.f
@@ -185,7 +185,7 @@
          solpcon = 0.
          cbodcon = 0.
          o2con = 0.
-         rch_cbod(jrch) = dmax1(1.e-6,rch_cbod(jrch))
+         rch_cbod(jrch) = dmax1(1.e-6_8, rch_cbod(jrch))
          wtrtot = wtrin + rchwtr
          algcon = (algin * wtrin + algae(jrch) * rchwtr) / wtrtot
          orgncon = (orgnin * wtrin + organicn(jrch) * rchwtr) / wtrtot

--- a/src/bmp_ri_pond.f
+++ b/src/bmp_ri_pond.f
@@ -106,7 +106,7 @@
           
          !Estimate TSS removal due to sedimentation
          if (sedconc>12.) then ! assume 12mg/l as equilibrium concentration, , Huber et al. 2006
-           ksed = min(134.8,41.1 * hpnd ** -0.999)  !decay coefficient, Huber et al. 2006
+           ksed = min(134.8,41.1 * hpnd ** (-0.999))  !decay coefficient, Huber et al. 2006
            td = 1. / nstep !detention time, day
            sedconc = (sedconc - 12.) * exp(-ksed * td) + 12.
          endif

--- a/src/bmp_sed_pond.f
+++ b/src/bmp_sed_pond.f
@@ -156,7 +156,7 @@
         
         !Estimate TSS removal due to sedimentation
          if (spndconc>sp_sede(sb,kk)) then
-           ksed = min(134.8,41.1 * hpnd ** -0.999)  !decay coefficient, Huber et al. 2006
+           ksed = min(134.8,41.1 * hpnd ** (-0.999))  !decay coefficient, Huber et al. 2006
            td = qpnd / qpipe / nstep !detention time, day
            spndconc = (spndconc - sp_sede(sb,kk)) * exp(-ksed * td) + 
      &           sp_sede(sb,kk)

--- a/src/carbon_new.f
+++ b/src/carbon_new.f
@@ -261,14 +261,14 @@
             else
               CNres = 0.43 * sol_rsd(k,j) / sol_fon(k,j)
             end if
-            CNres = dmax1(CNres, 15.)
+            CNres = dmax1(CNres, 15._8)
             
             if (sol_fop(k,j) < .01) then
               CPres = 400.
             else
               CPres = 0.43 * sol_rsd(k,j) / sol_fop(k,j)
             end if
-            CPres = dmax1(CPres, 400.)
+            CPres = dmax1(CPres, 400._8)
             
             !! CN of new organic matter (humified residue)
             rCNnew = fCNnew(sol_no3(k,j),sol_mass,CNres, 1.1D+02)   ! 110.)

--- a/src/carbon_zhang2.f90
+++ b/src/carbon_zhang2.f90
@@ -326,7 +326,8 @@
 		      OX = 0.
 		      !OX = 1 - (0.9* sol_z(k,j)/1000.) / (sol_z(k,j)/1000.+ exp(1.50-3.99*sol_z(k,j)/1000.))
 		      !OX = 1 - (0.8* sol_z(k,j)) / (sol_z(k,j)+ exp(1.50-3.99*sol_z(k,j)))  
-		      OX=1.-0.8*((sol_z(kk,j)+sol_z(kk-1,j))/2)/(((sol_z(kk,j)+sol_z(kk-1,j))/2)+EXP(18.40961-0.023683632*((sol_z(kk,j)+sol_z(kk-1,j))/2)))  			
+		      OX=1.-0.8*((sol_z(kk,j)+sol_z(kk-1,j))/2)/ &
+        &           (((sol_z(kk,j)+sol_z(kk-1,j))/2)+EXP(18.40961-0.023683632*((sol_z(kk,j)+sol_z(kk-1,j))/2)))
               !! compute combined factor
 		      CS = 0.
 		      CS=MIN(10.,SQRT(cdg*sut)*0.9*OX*X1)              

--- a/src/cfactor.f
+++ b/src/cfactor.f
@@ -83,7 +83,7 @@
         grcov_fr = laiday(j) / (laiday(j) + 
      *          Exp(1.748 - 1.748*laiday(j)))
         bio_frcov = 1. - grcov_fr * Exp(-.01*cht(j))
-        c = dmax1(1.e-10,rsd_frcov*bio_frcov)
+        c = dmax1(1.e-10_8,rsd_frcov*bio_frcov)
       end if
 
       usle_cfac(ihru) = c

--- a/src/dailycn.f
+++ b/src/dailycn.f
@@ -77,11 +77,11 @@
         end if
       else                        
         !! alternative CN method (function of plant ET) 
-        r2 = dmax1(3., sci(j))           
+        r2 = dmax1(3._8, sci(j))           
       end if
 
       if (sol_tmp(2,j) <= 0.) r2 = smx(j) * (1. - Exp(- cn_froz * r2))
-      r2 = dmax1(3.,r2)
+      r2 = dmax1(3._8,r2)
 
       cnday(j) = 25400. / (r2 + 254.)
       sol_cnsw(j) = sol_sw(j)

--- a/src/gw_no3.f
+++ b/src/gw_no3.f
@@ -105,16 +105,16 @@
       revapn = xx * revapday
       gwseepn = xx * gwseep
 
-      revapn = dmax1(1.e-6,revapn)
-      gwseepn = dmax1(1.e-6,gwseepn)
+      revapn = dmax1(1.e-6_8,revapn)
+      gwseepn = dmax1(1.e-6_8,gwseepn)
 
 !! subtract nitrate losses from the shallow aquifer
       shallst_n(j) = shallst_n(j) - no3gw(j) - revapn - gwseepn
-      shallst_n(j) = dmax1 (0., shallst_n(j))
+      shallst_n(j) = dmax1 (0._8, shallst_n(j))
 
 !! compute nitrate losses in the groundwater
       shallst_n(j) = shallst_n(j) * gw_nloss(j)
-      shallst_n(j) = dmax1(0., shallst_n(j))
+      shallst_n(j) = dmax1(0._8, shallst_n(j))
   
       return
       end

--- a/src/hydroinit.f
+++ b/src/hydroinit.f
@@ -107,7 +107,7 @@
 
 !!    compute delivery ratio
       rto = tconc(j) / sub_tc(hru_sub(j))
-      dr_sub(j) = dmin1(.95,rto ** .5)
+      dr_sub(j) = dmin1(.95_8,rto ** .5)
 
 
 !!    compute fraction of surface runoff that is reaching the main channel

--- a/src/irr_rch.f
+++ b/src/irr_rch.f
@@ -216,7 +216,7 @@
                 end if
                 if (xx > 0.) then
                   rtwtr = rtwtr - xx
-                  rtwtr = dmax1(0., rtwtr)
+                  rtwtr = dmax1(0._8, rtwtr)
                 end if
 
                 !! advance irrigation operation number

--- a/src/nlch.f
+++ b/src/nlch.f
@@ -154,8 +154,8 @@
 
 
       nloss = (2.18 * dis_stream(j) - 8.63) / 100.
-      nloss = dmax1(0.,nloss)
-      nloss = dmin1(1.,nloss)
+      nloss = dmax1(0._8,nloss)
+      nloss = dmin1(1._8,nloss)
       latno3(j) = (1. - nloss) * latno3(j)
 
       return

--- a/src/nminrl.f
+++ b/src/nminrl.f
@@ -281,16 +281,16 @@
         end if
             decr = Max(decr_min, decr)
             decr = Min(decr, 1.)
-            sol_rsd(k,j) = dmax1(1.e-6,sol_rsd(k,j))
+            sol_rsd(k,j) = dmax1(1.e-6_8,sol_rsd(k,j))
             rdc = decr * sol_rsd(k,j)
             sol_rsd(k,j) = sol_rsd(k,j) - rdc
             if (sol_rsd(k,j) < 0.) sol_rsd(k,j) = 0.
             rmn1 = decr * sol_fon(k,j)
-            sol_fop(k,j) = dmax1(1.e-6,sol_fop(k,j))
+            sol_fop(k,j) = dmax1(1.e-6_8,sol_fop(k,j))
             rmp = decr * sol_fop(k,j)
 
             sol_fop(k,j) = sol_fop(k,j) - rmp
-            sol_fon(k,j) = dmax1(1.e-6,sol_fon(k,j))
+            sol_fon(k,j) = dmax1(1.e-6_8,sol_fon(k,j))
             sol_fon(k,j) = sol_fon(k,j) - rmn1
             sol_no3(k,j) = sol_no3(k,j) + .8 * rmn1
             sol_aorgn(k,j) = sol_aorgn(k,j) + .2 * rmn1

--- a/src/nup.f
+++ b/src/nup.f
@@ -163,8 +163,8 @@
           else
             xx = 1.
           end if
-          strsn(j) = dmax1(strsn(j), xx)
-          strsn(j) = dmin1(strsn(j), 1.)
+          strsn(j) = dmax1(strsn(j), real(xx,8))
+          strsn(j) = dmin1(strsn(j), 1._8)
       end select
 
       return

--- a/src/percmain.f
+++ b/src/percmain.f
@@ -304,7 +304,7 @@
         end do
         if (sumqtile > 0.) then
           qtile = qtile - sumqtile
-          qtile = dmax1(0., qtile)
+          qtile = dmax1(0._8, qtile)
         end if
       end if
 

--- a/src/pminrl2.f
+++ b/src/pminrl2.f
@@ -189,7 +189,7 @@
         
         xx = actp(l) + (actp(l) * rto)
         if (xx > 1.e-6) then
-      	 ssp = 25.044 * xx ** -0.3833 
+      	 ssp = 25.044 * xx ** (-0.3833) 
         end if
         
 	  ! limit ssp to range in measured data

--- a/src/readbsn.f
+++ b/src/readbsn.f
@@ -375,6 +375,7 @@
       character (len=13) :: wwqfile
       integer :: eof, numlu
       real*8 :: escobsn, epcobsn
+      integer :: ii, pos
 !!      real*8 :: r2adj_bsn  !D. Moriasi 4/8/2014    
 
 !!    initialize variables

--- a/src/readsub.f
+++ b/src/readsub.f
@@ -460,7 +460,7 @@
       call readwus
 
 !! sediment delivery ration for the subbasin..... urban modeling by J.Jeong
-	dratio(i) = 0.42 * sub_km(i) ** -0.125
+	dratio(i) = 0.42 * sub_km(i) ** (-0.125)
 	if(dratio(i)>0.9) dratio(i) = 0.9
 
       close (101)

--- a/src/soil_chem.f
+++ b/src/soil_chem.f
@@ -268,7 +268,7 @@
 	      actp = sol_actp(j,i) / conv_wt(j,i) * 1000000.
 		    solp = sol_solp(j,i) / conv_wt(j,i) * 1000000.
             !! estimate Total Mineral P in this soil based on data from sharpley 2004
-		    ssp = 25.044 * (actp + solp)** -0.3833
+		    ssp = 25.044 * (actp + solp)** (-0.3833)
 		    !!limit SSP Range
 		    if (SSP > 7.) SSP = 7.
 		    if (SSP < 1.) SSP = 1.	      	  

--- a/src/virtual.f
+++ b/src/virtual.f
@@ -324,15 +324,15 @@
         sub_dsag(sb) = sub_dsag(sb) + sagyld(j)
         sub_dlag(sb) = sub_dlag(sb) + lagyld(j)
 
-        surqno3(j) = dmax1(1.e-12,surqno3(j))
-        latno3(j) = dmax1(1.e-12,latno3(j))
-        no3gw(j) = dmax1(1.e-12,no3gw(j))
-        surqsolp(j) = dmax1(1.e-12,surqsolp(j))
-        minpgw(j) = dmax1(1.e-12,minpgw(j))
-        sedorgn(j) = dmax1(1.e-12,sedorgn(j))
-        sedorgp(j) = dmax1(1.e-12,sedorgp(j))
-        sedminpa(j) = dmax1(1.e-12,sedminpa(j))
-        sedminps(j) = dmax1(1.e-12,sedminps(j))
+        surqno3(j) = dmax1(1.e-12_8,surqno3(j))
+        latno3(j) = dmax1(1.e-12_8,latno3(j))
+        no3gw(j) = dmax1(1.e-12_8,no3gw(j))
+        surqsolp(j) = dmax1(1.e-12_8,surqsolp(j))
+        minpgw(j) = dmax1(1.e-12_8,minpgw(j))
+        sedorgn(j) = dmax1(1.e-12_8,sedorgn(j))
+        sedorgp(j) = dmax1(1.e-12_8,sedorgp(j))
+        sedminpa(j) = dmax1(1.e-12_8,sedminpa(j))
+        sedminps(j) = dmax1(1.e-12_8,sedminps(j))
         
 
       !! subbasin averages: nutrients

--- a/src/watqual.f
+++ b/src/watqual.f
@@ -279,7 +279,7 @@
          solpcon = 0.
          cbodcon = 0.
          o2con = 0.
-         rch_cbod(jrch) = dmax1(1.e-6,rch_cbod(jrch))
+         rch_cbod(jrch) = dmax1(1.e-6_8,rch_cbod(jrch))
          wtrtot = wtrin + rchwtr
          algcon = (algin * wtrin + algae(jrch) * rchwtr) / wtrtot
          orgncon = (orgnin * wtrin + organicn(jrch) * rchwtr) / wtrtot
@@ -460,7 +460,7 @@
          yy = ai5 * Theta(bc1mod,thbc1,wtmp) * nh3con
          zz = ai6 * Theta(bc2mod,thbc2,wtmp) * no2con
          rch_dox(jrch) = o2con + (uu + vv - ww - xx - yy - zz) * tday
-         rch_dox(jrch) = dmin1(0.1, rch_dox(jrch))
+         rch_dox(jrch) = dmin1(0.1_8, rch_dox(jrch))
          
          !algea O2 production minus respiration
          !if (vv > 0.) then

--- a/src/wattable.f
+++ b/src/wattable.f
@@ -85,7 +85,7 @@
       else
         w2 = 0.
       end if
-      w1 = dmin1 (0.1,abs(w2))
+      w1 = dmin1 (0.1_8,abs(w2))
       if (w2 > 0.) then
         wtl = wtab_mn(j)
       else


### PR DESCRIPTION
Hi @crazyzlj , 

There were a number of compile errors on Cray. These fall into several categories
1. x** -0.999 does not compile, one needs to add parentheses, ie x** (-0.999)
2. dmax1(1., x) does not compile because 1. is a real. The fix is dmax1(1._8, x)
3. File carbon_zhang2.f90 had a line that overflowed the 132 character limit for f90 source files
This solves #6 